### PR TITLE
made the cursor visible in the launcher

### DIFF
--- a/Armament/Assets/MyScripts/Launcher/Launcher.cs
+++ b/Armament/Assets/MyScripts/Launcher/Launcher.cs
@@ -79,6 +79,7 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
         void Start()
         {
             //progressLabel.SetActive(false);
+            Cursor.visible = true;
             Cursor.lockState = CursorLockMode.None;//frees up the cursor
             controlPanel.SetActive(true);
             

--- a/Armament/ProjectSettings/ProjectVersion.txt
+++ b/Armament/ProjectSettings/ProjectVersion.txt
@@ -1,0 +1,1 @@
+m_EditorVersion: 2018.3.6f1


### PR DESCRIPTION
 fixed: when we left a game it was leaving the cursor locked and invisible from the prev state.

Also to clarify the last commit in case it wasn't clear-- you can swap to the red gun but you can't swap back due to having to disable onTrigger